### PR TITLE
bugfix: GPU device registration during runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 .coverage
 .ropeproject
 log*.txt
+
+# vscode files
+settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /block
 COPY requirements.txt /block
 
 # Install the Python requirements.
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --use-feature=2020-resolver
 
 # Copy the code into the container.
 COPY src /block/src

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-"publicVersion": "2.3.4"
+"publicVersion": "2.3.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 up42-blockutils
-tensorflow>=2.3.*
+tensorflow==2.3.0
 keras
 numpy
 rasterio


### PR DESCRIPTION
**Context**
From runtime logs, it turns out that the env var `LD_LIBRARY_PATH` that needs to be appended to the sys path is not set properly. This is associated with NVIDIA CUDA libs that handles tensor processing on GPUs. During runtime the GPU is discovered but not registered with tensorflow due to missing path entry. The TF falls back to CPU instead. Ideally, irrespective of tensor shape (i.e. channel first or last), the block should run on GPU.

**Behaviour**
The block is built on tf2 base image that uses tf version `2.1.0`. On top of that during docker build the requirements are installed which also contained `tensorflow>=2.3.*`. However, with new tf version `2.4.0` release at the end of Dec 2020. The lib was installing that version. The latest version of tensorflow is expecting runtime built with CUDA 11.0 which is not the case. On top of that, the base container for GPU enabled machines used by up42 infra is built with CUDA 10.0. (mainly due to [GKE compatibility](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda))

**Resolution**
Pin TF version to `2.3.0`

The pinned version of the block was tested as a custom block on the platform and the not only GPU was discovered successfully but the job too!